### PR TITLE
Restrict Excel download to internal IP range

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,6 +491,6 @@
   </div>
 
   <!-- 메인 스크립트 -->
- <script src="script.js?v=1.0.3"></script>
+ <script src="script.js?v=1.0.4"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- limit Excel downloads to clients in the 10.101.*.* IP range
- bump script version to 1.0.3 for cache busting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7ac0c83c083249ee66033fb22ce76