### PR TITLE
Add AS history count field

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,7 @@
           <th data-field="조치계획">조치계획<div class="col-resizer"></div></th>
           <th data-field="접수내용">접수내용<div class="col-resizer"></div></th>
           <th data-field="조치결과">조치결과<div class="col-resizer"></div></th>
+          <th data-field="historyCount">AS접수건수<div class="col-resizer"></div></th>
           <!-- 히스토리 AI 요약 열 -->
           <th>히스토리</th>
           <th data-field="AS접수일자">AS접수일자<div class="col-resizer"></div></th>

--- a/style.css
+++ b/style.css
@@ -1240,6 +1240,7 @@ th[data-field="동작여부"], td[data-field="동작여부"] { min-width: 120px;
 th[data-field="조치계획"], td[data-field="조치계획"] { min-width: 180px; }
 th[data-field="접수내용"], td[data-field="접수내용"] { min-width: 180px; }
 th[data-field="조치결과"], td[data-field="조치결과"] { min-width: 180px; }
+th[data-field="historyCount"], td[data-field="historyCount"] { min-width: 120px; }
 th[data-field="AS접수일자"], td[data-field="AS접수일자"] { min-width: 120px; }
 th[data-field="기술적종료일"], td[data-field="기술적종료일"] { min-width: 120px; }
 th[data-field="경과일"], td[data-field="경과일"] { min-width: 60px; }


### PR DESCRIPTION
## Summary
- Show AS history counts per project between action results and history columns
- Support total counts from 2020 in basic view and yearly breakdown in extended view
- Style and translate new column

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c81f267483248026174af78096b0