### PR TITLE
Add yearly AS history columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,7 @@
           <th data-field="조치계획">조치계획<div class="col-resizer"></div></th>
           <th data-field="접수내용">접수내용<div class="col-resizer"></div></th>
           <th data-field="조치결과">조치결과<div class="col-resizer"></div></th>
+          <th data-field="historyCount">AS접수건수<div class="col-resizer"></div></th>
           <!-- 히스토리 AI 요약 열 -->
           <th>히스토리</th>
           <th data-field="AS접수일자">AS접수일자<div class="col-resizer"></div></th>

--- a/script.js
+++ b/script.js
@@ -90,21 +90,27 @@ let g_apiConfig = {
   baseUrl: "https://api.vesselfinder.com/masterdata"
 };
 
+// 연도별 AS 접수 건수 열 생성
+const historyStartYear = 2020;
+const currentYear = new Date().getFullYear();
+const historyYears = Array.from({ length: currentYear - historyStartYear + 1 }, (_, i) => historyStartYear + i);
+const historyYearColumns = historyYears.map(y => `historyCount${y}`);
+
 // 기본 테이블 열 정의
 const basicColumns = [
-  'checkbox', '공번', '공사', 'imo', 'hull', 'shipName', 'shipowner', 'repMail', 'shipType', 
-  'group', 'shipyard', 'contract', 'asType', 'delivery', 'warranty', 
-  'manager', '현황', '현황번역', '동작여부', 'history', 'AS접수일자', '기술적종료일', 
+  'checkbox', '공번', '공사', 'imo', 'hull', 'shipName', 'shipowner', 'repMail', 'shipType',
+  'group', 'shipyard', 'contract', 'asType', 'delivery', 'warranty',
+  'manager', '현황', '현황번역', '동작여부', 'historyCount', 'history', 'AS접수일자', '기술적종료일',
   '경과일', '정상지연', '지연 사유', '수정일'
 ];
 
 // 모든 테이블 열 정의
 const allColumns = [
   'checkbox', '공번', '공사', 'imo', 'api_name', 'api_owner', 'api_manager', 'api_apply',
-  'hull', 'shipName', 'shipowner', 'repMail', 'shipType', 'scale', '구분', 'major', 
-  'group', 'shipyard', 'contract', 'asType', 'delivery', 'warranty', 'prevManager', 
-  'manager', '현황', '현황번역', 'ai_summary', '동작여부', '조치계획', '접수내용', 
-  '조치결과', 'history', 'AS접수일자', '기술적종료일', '경과일', '정상지연', '지연 사유', '수정일'
+  'hull', 'shipName', 'shipowner', 'repMail', 'shipType', 'scale', '구분', 'major',
+  'group', 'shipyard', 'contract', 'asType', 'delivery', 'warranty', 'prevManager',
+  'manager', '현황', '현황번역', 'ai_summary', '동작여부', '조치계획', '접수내용',
+  '조치결과', 'historyCount', ...historyYearColumns, 'history', 'AS접수일자', '기술적종료일', '경과일', '정상지연', '지연 사유', '수정일'
 ];
 
 // 언어별 텍스트 사전
@@ -178,6 +184,7 @@ const translations = {
     "조치계획": "조치계획",
     "접수내용": "접수내용",
     "조치결과": "조치결과",
+    "AS접수건수": "AS접수건수",
     "AS접수일자": "AS접수일자",
     "기술적종료일": "기술적종료일",
     "경과일": "경과일",
@@ -267,6 +274,7 @@ const translations = {
     "조치계획": "Action Plan",
     "접수내용": "Receipt Details",
     "조치결과": "Action Results",
+    "AS접수건수": "AS Count",
     "AS접수일자": "AS Receipt Date",
     "기술적종료일": "Technical End Date",
     "경과일": "Elapsed Days",
@@ -355,6 +363,7 @@ const translations = {
     "조치계획": "措施计划",
     "접수내용": "接收内容",
     "조치결과": "措施结果",
+    "AS접수건수": "AS数量",
     "AS접수일자": "AS接收日期",
     "기술적종료일": "技术终止日期",
     "경과일": "经过天数",
@@ -443,6 +452,7 @@ const translations = {
     "조치계획": "措置計画",
     "접수내용": "受付内容",
     "조치결과": "措置結果",
+    "AS접수건수": "AS件数",
     "AS접수일자": "AS受付日",
     "기술적종료일": "技術的終了日",
     "경과일": "経過日数",
@@ -1031,7 +1041,7 @@ function renderTableHeaders() {
   if (!thead) return;
   
   const columnsToShow = isExtendedView ? allColumns : basicColumns;
-  
+
   const headerDefinitions = {
     'checkbox': { field: null, text: '', isCheckbox: true },
     '공번': { field: '공번', text: '공번' },
@@ -1064,6 +1074,7 @@ function renderTableHeaders() {
     '조치계획': { field: '조치계획', text: '조치계획' },
     '접수내용': { field: '접수내용', text: '접수내용' },
     '조치결과': { field: '조치결과', text: '조치결과' },
+    'historyCount': { field: null, text: 'AS접수건수', isHistoryCount: true },
     'history': { field: null, text: '히스토리', isHistory: true },
     'AS접수일자': { field: 'AS접수일자', text: 'AS접수일자' },
     '기술적종료일': { field: '기술적종료일', text: '기술적종료일' },
@@ -1072,15 +1083,18 @@ function renderTableHeaders() {
     '지연 사유': { field: '지연 사유', text: '지연 사유' },
     '수정일': { field: '수정일', text: '수정일' }
   };
-  
+
+  historyYears.forEach(year => {
+    headerDefinitions[`historyCount${year}`] = { field: null, text: String(year) };
+  });
+
   thead.innerHTML = '';
-  
+
   columnsToShow.forEach(columnKey => {
     const headerDef = headerDefinitions[columnKey];
     if (!headerDef) return;
-    
+
     const th = document.createElement('th');
-    
     if (headerDef.isCheckbox) {
       const checkbox = document.createElement('input');
       checkbox.type = 'checkbox';
@@ -1089,29 +1103,28 @@ function renderTableHeaders() {
       th.appendChild(checkbox);
     } else {
       const translatedText = translations[currentLanguage][headerDef.text] || headerDef.text;
-      
+      th.setAttribute('data-field', headerDef.field || columnKey);
+
       if (headerDef.field) {
-        th.setAttribute('data-field', headerDef.field);
         th.style.cursor = 'pointer';
-        
         const textNode = document.createTextNode(translatedText);
         th.appendChild(textNode);
-        
+
         if (sortField === headerDef.field) {
           const sortIndicator = document.createElement('span');
           sortIndicator.className = 'sort-indicator';
-          sortIndicator.innerHTML = sortAsc ? ' &#9650;' : ' &#9660;';
+          sortIndicator.innerHTML = sortAsc ? ' \u25b2' : ' \u25bc';
           th.appendChild(sortIndicator);
         }
       } else {
         th.textContent = translatedText;
       }
-      
+
       const resizer = document.createElement('div');
       resizer.className = 'col-resizer';
       th.appendChild(resizer);
     }
-    
+
     thead.appendChild(th);
   });
 }
@@ -2044,50 +2057,76 @@ function testConnection() {
     });
 }
 
-function loadData() {
-  db.ref(asPath).once('value').then(snap => {
-    const val = snap.val() || {};
-    
-    asData = [];
-    Object.keys(val).forEach(key => {
-      const r = val[key];
-      
-      // 빈 객체이거나 유효하지 않은 데이터는 건너뛰기
-      if (!r || typeof r !== 'object') return;
-      
-      // 최소한 하나 이상의 필수 필드가 있는지 확인
-      const hasRequiredFields = r.공번 || r.imo || r.hull || r.shipName || r.manager || r.shipowner;
-      if (!hasRequiredFields) return;
-      
-      // uid가 없으면 key를 uid로 설정
-      if (!r.uid) r.uid = key;
-      
-      // 호환 처리
-      if (r["현 담당"] && !r.manager) r.manager = r["현 담당"];
-      if (r["SHIPOWNER"] && !r.shipowner) r.shipowner = r["SHIPOWNER"];
-      if (r.group && typeof r.group !== 'string') r.group = String(r.group);
-      if (!("AS접수일자" in r)) r["AS접수일자"] = "";
-      if (!("정상지연" in r)) r["정상지연"] = "";
-      if (!("지연 사유" in r)) r["지연 사유"] = "";
-      if (!("수정일" in r)) r["수정일"] = "";
-      if (!("api_name" in r)) r["api_name"] = "";
-      if (!("api_owner" in r)) r["api_owner"] = "";
-      if (!("api_manager" in r)) r["api_manager"] = "";
-      if (!("현황번역" in r)) r["현황번역"] = "";
-      
-      // 동작여부 값 변환
-      if (r.동작여부 === "정상A" || r.동작여부 === "정상B" || r.동작여부 === "유상정상") {
-        r.동작여부 = "정상";
-      }
-      
-      asData.push(r);
-    });
-    
-    console.log(`데이터 로드 완료: 총 ${asData.length}개 (원본: ${Object.keys(val).length}개)`);
-    
-    dataLoaded = true;
-    updateSidebarList();
+async function loadData() {
+  const snap = await db.ref(asPath).once('value');
+  const val = snap.val() || {};
+
+  asData = [];
+  Object.keys(val).forEach(key => {
+    const r = val[key];
+
+    // 빈 객체이거나 유효하지 않은 데이터는 건너뛰기
+    if (!r || typeof r !== 'object') return;
+
+    // 최소한 하나 이상의 필수 필드가 있는지 확인
+    const hasRequiredFields = r.공번 || r.imo || r.hull || r.shipName || r.manager || r.shipowner;
+    if (!hasRequiredFields) return;
+
+    // uid가 없으면 key를 uid로 설정
+    if (!r.uid) r.uid = key;
+
+    // 호환 처리
+    if (r["현 담당"] && !r.manager) r.manager = r["현 담당"];
+    if (r["SHIPOWNER"] && !r.shipowner) r.shipowner = r["SHIPOWNER"];
+    if (r.group && typeof r.group !== 'string') r.group = String(r.group);
+    if (!("AS접수일자" in r)) r["AS접수일자"] = "";
+    if (!("정상지연" in r)) r["정상지연"] = "";
+    if (!("지연 사유" in r)) r["지연 사유"] = "";
+    if (!("수정일" in r)) r["수정일"] = "";
+    if (!("api_name" in r)) r["api_name"] = "";
+    if (!("api_owner" in r)) r["api_owner"] = "";
+    if (!("api_manager" in r)) r["api_manager"] = "";
+    if (!("현황번역" in r)) r["현황번역"] = "";
+
+    // 동작여부 값 변환
+    if (r.동작여부 === "정상A" || r.동작여부 === "정상B" || r.동작여부 === "유상정상") {
+      r.동작여부 = "정상";
+    }
+
+    asData.push(r);
   });
+
+  console.log(`데이터 로드 완료: 총 ${asData.length}개 (원본: ${Object.keys(val).length}개)`);
+
+  await loadHistoryCounts();
+
+  dataLoaded = true;
+  updateSidebarList();
+  applyFilters();
+}
+
+// 히스토리 건수 로드
+async function loadHistoryCounts() {
+  const tasks = asData.map(row =>
+    getProjectHistoryRef(row.공번).once('value').then(snapshot => {
+      const data = snapshot.val() || {};
+      const perYear = {};
+      let total = 0;
+      Object.values(data).forEach(rec => {
+        if (!rec.AS접수일자) return;
+        const year = parseInt(rec.AS접수일자.substring(0, 4), 10);
+        if (year >= 2020) {
+          perYear[year] = (perYear[year] || 0) + 1;
+          total++;
+        }
+      });
+      row.historyCounts = { perYear, total };
+    }).catch(err => {
+      console.error('히스토리 건수 로드 오류:', err);
+      row.historyCounts = { perYear: {}, total: 0 };
+    })
+  );
+  await Promise.all(tasks);
 }
 
 // onCellChange 함수
@@ -2488,6 +2527,8 @@ function createTableCell(row, columnKey) {
       aiBtn.addEventListener('click', () => summarizeAndUpdateRow(row.uid));
       aiTd.appendChild(aiBtn);
       return aiTd;
+    case 'historyCount':
+      return createHistoryCountCell(row);
     case 'history':
       return createHistoryCell(row);
     case '경과일':
@@ -2497,6 +2538,12 @@ function createTableCell(row, columnKey) {
     case '수정일':
       return createModifiedDateCell(row);
     default:
+      if (columnKey.startsWith('historyCount')) {
+        const year = parseInt(columnKey.replace('historyCount', ''), 10);
+        if (!isNaN(year)) {
+          return createHistoryYearCell(row, year);
+        }
+      }
       // 알려진 컬럼인지 확인
       const knownColumns = [
         '공번', '공사', 'imo', 'api_name', 'api_owner', 'api_manager',
@@ -2567,6 +2614,24 @@ function createHistoryCell(row) {
   btn.style.cursor = "pointer";
   btn.addEventListener('click', () => showHistoryDataWithFullscreen(row.공번));
   td.appendChild(btn);
+  return td;
+}
+
+// 히스토리 건수 셀 생성
+function createHistoryCountCell(row) {
+  const td = document.createElement('td');
+  td.dataset.field = 'historyCount';
+  const counts = row.historyCounts || { perYear: {}, total: 0 };
+  td.textContent = counts.total || 0;
+  return td;
+}
+
+// 연도별 히스토리 건수 셀 생성
+function createHistoryYearCell(row, year) {
+  const td = document.createElement('td');
+  td.dataset.field = `historyCount${year}`;
+  const counts = row.historyCounts || { perYear: {}, total: 0 };
+  td.textContent = counts.perYear[year] || 0;
   return td;
 }
 
@@ -3678,22 +3743,44 @@ function downloadExcel() {
   const originalText = btn.textContent;
   btn.textContent = "다운로드 중...";
   btn.disabled = true;
-  
+
   setTimeout(() => {
     try {
-const arr = asData.map(d => ({
-  공번: d.공번, 공사: d.공사, IMO: d.imo, HULL: d.hull, SHIPNAME: d.shipName,
-  SHIPOWNER: d.shipowner, 'API_NAME': d.api_name, 'API_OWNER': d.api_owner, 'API_MANAGER': d.api_manager,
-  '호선 대표메일': d.repMail, 'SHIP TYPE': d.shipType, SCALE: d.scale, 구분: d.구분,
-  주요선사: d.major, 그룹: d.group, SHIPYARD: d.shipyard,
-        계약: d.contract, 'AS 구분': d.asType, 인도일: d.delivery, 보증종료일: d.warranty,
-        '전 담당': d.prevManager, '현 담당': d.manager, 현황: d.현황, 현황번역: d.현황번역, 동작여부: d.동작여부,
-        조치계획: d.조치계획, 접수내용: d.접수내용, 조치결과: d.조치결과,
-        AS접수일자: d["AS접수일자"], 기술적종료일: d["기술적종료일"],
-        정상지연: d["정상지연"], '지연 사유': d["지연 사유"], '수정일': d["수정일"]
-      }));
-      
-      const ws = XLSX.utils.json_to_sheet(arr);
+      const arr = asData.map(d => {
+        const counts = d.historyCounts || { perYear: {}, total: 0 };
+        const row = {
+          공번: d.공번, 공사: d.공사, IMO: d.imo, HULL: d.hull, SHIPNAME: d.shipName,
+          SHIPOWNER: d.shipowner, 'API_NAME': d.api_name, 'API_OWNER': d.api_owner, 'API_MANAGER': d.api_manager,
+          '호선 대표메일': d.repMail, 'SHIP TYPE': d.shipType, SCALE: d.scale, 구분: d.구분,
+          주요선사: d.major, 그룹: d.group, SHIPYARD: d.shipyard,
+          계약: d.contract, 'AS 구분': d.asType, 인도일: d.delivery, 보증종료일: d.warranty,
+          '전 담당': d.prevManager, '현 담당': d.manager, 현황: d.현황, 현황번역: d.현황번역, 동작여부: d.동작여부,
+          조치계획: d.조치계획, 접수내용: d.접수내용, 조치결과: d.조치결과,
+          'AS접수건수': counts.total
+        };
+        historyYears.forEach(y => {
+          row[String(y)] = counts.perYear[y] || 0;
+        });
+        row['AS접수일자'] = d['AS접수일자'];
+        row['기술적종료일'] = d['기술적종료일'];
+        row['정상지연'] = d['정상지연'];
+        row['지연 사유'] = d['지연 사유'];
+        row['수정일'] = d['수정일'];
+        return row;
+      });
+
+      const headers = [
+        '공번', '공사', 'IMO', 'HULL', 'SHIPNAME', 'SHIPOWNER',
+        'API_NAME', 'API_OWNER', 'API_MANAGER', '호선 대표메일',
+        'SHIP TYPE', 'SCALE', '구분', '주요선사', '그룹', 'SHIPYARD',
+        '계약', 'AS 구분', '인도일', '보증종료일', '전 담당', '현 담당',
+        '현황', '현황번역', '동작여부', '조치계획', '접수내용', '조치결과',
+        'AS접수건수', ...historyYears.map(String),
+        'AS접수일자', '기술적종료일', '정상지연', '지연 사유', '수정일'
+      ];
+
+      const ws = XLSX.utils.json_to_sheet(arr, { header: headers, skipHeader: true });
+      XLSX.utils.sheet_add_aoa(ws, [headers], { origin: 'A1' });
       const wb = XLSX.utils.book_new();
       XLSX.utils.book_append_sheet(wb, ws, "AS_Data");
       

--- a/style.css
+++ b/style.css
@@ -1240,6 +1240,8 @@ th[data-field="동작여부"], td[data-field="동작여부"] { min-width: 120px;
 th[data-field="조치계획"], td[data-field="조치계획"] { min-width: 180px; }
 th[data-field="접수내용"], td[data-field="접수내용"] { min-width: 180px; }
 th[data-field="조치결과"], td[data-field="조치결과"] { min-width: 180px; }
+th[data-field^="historyCount"], td[data-field^="historyCount"] { min-width: 80px; }
+th[data-field="historyCount"], td[data-field="historyCount"] { min-width: 120px; }
 th[data-field="AS접수일자"], td[data-field="AS접수일자"] { min-width: 120px; }
 th[data-field="기술적종료일"], td[data-field="기술적종료일"] { min-width: 120px; }
 th[data-field="경과일"], td[data-field="경과일"] { min-width: 60px; }


### PR DESCRIPTION
## Summary
- Add dynamic columns for yearly AS history counts from 2020 onward
- Render per-year counts and totals in table headers and cells
- Export yearly and total AS counts as separate columns in Excel
- Ensure Excel export lists yearly AS counts after the total count column

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c81f267483248026174af78096b0